### PR TITLE
support wildcard domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ nofollow:
 - **field** - The scope you want the plugin to proceed, can be 'site' or 'post'. Default value is `site`.
   - 'post' - Only add nofollow attribute to external links in your post content
   - 'site' - Add nofollow attribute to external links of whole sites
-- **exclude** - Exclude hostname. Specify subdomain when applicable, including `www`.
-  - 'exclude1.com' does not apply to `www.exclude1.com` nor `en.exclude1.com`.
+- **exclude** - Exclude hostname. Subdomain also supported well, such as `www` or `app`.
+  - 'exclude1.com' now apply to `www.exclude1.com` and `en.exclude1.com` in this [commit](https://github.com/tangkunyin/hexo-filter-nofollow/commit/cf05a07054536dfaa36f986493e678252f31ad45)

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -12,11 +12,11 @@ function isExternal(url, config) {
 
   if (exclude && exclude.length) {
     for (const i of exclude) {
-      if (host === i) return false;
+      if (host === i || host.endsWith(i)) return false;
     }
   }
 
-  if (host !== sitehost) return true;
+  if (host !== sitehost && !host.endsWith(sitehost)) return true;
 
   return false;
 }
@@ -34,7 +34,7 @@ module.exports = function(data) {
     return data.replace(/<a.*?(href=['"](.*?)['"]).*?>/gi, (str, hrefStr, href) => {
       if (!isExternal(href, config)) return str;
 
-      let noFollow = ['noopener', 'external', 'nofollow', 'noreferrer'];
+      let noFollow = ['external', 'nofollow', 'noreferrer', 'noopener'];
 
       if (/rel=/gi.test(str)) {
         str = str.replace(/\srel="(.*?)"/gi, (relStr, rel) => {

--- a/lib/filter.js
+++ b/lib/filter.js
@@ -12,11 +12,11 @@ function isExternal(url, config) {
 
   if (exclude && exclude.length) {
     for (const i of exclude) {
-      if (host === i || host.endsWith(i)) return false;
+      if (i === host || (host && host.endsWith(i))) return false;
     }
   }
 
-  if (host !== sitehost && !host.endsWith(sitehost)) return true;
+  if (sitehost !== host && (host && !host.endsWith(sitehost))) return true;
 
   return false;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-filter-nofollow",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Add nofollow attribute to all external links automatically",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

Support wildcard domain, that means subdomain also supported well, such as `www` or `en`.

Now we can just configure only `exclude.com` and it will be worked on `*.exclude.com`

## Additional information

No!
